### PR TITLE
Change the suggested JS package command to pull the JSR version.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -16,9 +16,9 @@ JavaScript package
 --
 - [uklatn JavaScript package](js/)
 
-Install with npm:
+Install with JSR:
 ```sh
-npm install uklatn
+npx jsr add @paiv/uklatn
 ```
 
 Usage:


### PR DESCRIPTION
I noticed that the version of the package fetched when running `npm install uklatn` lacks Typescript type information. The package is also uploaded to JSR, and this has the required declarations file. This PR changes the documentation to point to the version hosted here: https://jsr.io/@paiv/uklatn@1.20.0 using the packaging command suggested on that page `npx jsr add @paiv/uklatn`.

Thanks for the handy package.

Слава Україні!